### PR TITLE
Export `eps` and fix its definition

### DIFF
--- a/src/Float8s.jl
+++ b/src/Float8s.jl
@@ -8,7 +8,7 @@ module Float8s
                 (+), (-), (*), (/), (\), (^),
                 sin,cos,tan,asin,acos,atan,sinh,cosh,tanh,asinh,acosh,
                 atanh,exp,exp2,exp10,expm1,log,log2,log10,sqrt,cbrt,log1p,
-                atan,hypot,round,show,nextfloat,prevfloat,
+                atan,hypot,round,show,nextfloat,prevfloat,eps,
                 promote_rule, sign, signbit
 
     export Float8, Float8_4, NaN8, Inf8, NaN8_4, Inf8_4

--- a/src/float8.jl
+++ b/src/float8.jl
@@ -32,8 +32,8 @@ n_significant_bits(::Type{Float8_4}) = 3
 bias(::Type{Float8}) = 3
 bias(::Type{Float8_4}) = 7
 
-eps(::Type{Float8}) = Float8(0x02)
-eps(::Type{Float8_4}) = Float8_4(0x20)
+eps(x::AbstractFloat8) = max(x-prevfloat(x), nextfloat(x)-x)
+eps(::Type{T}) where T <: AbstractFloat8 = eps(one(T))
 
 # define inifinities and nan
 inf8(::Type{Float8}) = Float8(0x70)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -251,7 +251,10 @@ end
     @test Inf8_4 == nextfloat(Inf8_4)
     @test -floatmax(Float8_4) == nextfloat(-Inf8_4)
 
-    @test eps(Float8) == nextfloat(Float8(1)) - Float8(1)
+    for T in (Float8, Float8_4)
+        @test eps(T) == nextfloat(T(1)) - T(1)
+        @test eps(one(T)) == eps(T)
+    end
 end
 
 @testset "Prevfloat" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -250,6 +250,8 @@ end
     @test NaN8_4 != nextfloat(NaN8_4)
     @test Inf8_4 == nextfloat(Inf8_4)
     @test -floatmax(Float8_4) == nextfloat(-Inf8_4)
+
+    @test eps(Float8) == nextfloat(Float8(1)) - Float8(1)
 end
 
 @testset "Prevfloat" begin


### PR DESCRIPTION
This redefined `eps` follows the definitions in `Base`:
https://docs.julialang.org/en/v1/base/base/#Base.eps-Tuple{Type{%3C:AbstractFloat}}
and is now "exported" because it overloads `Base.eps`